### PR TITLE
The blocksize on the naburn cpm disk format is now 4096

### DIFF
--- a/Brick Battle/diskdefs
+++ b/Brick Battle/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/CPM Life/diskdefs
+++ b/CPM Life/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/Game Dev 4/diskdefs
+++ b/Game Dev 4/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/Game Dev 5/diskdefs
+++ b/Game Dev 5/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/HTTP Get Test CPM/diskdefs
+++ b/HTTP Get Test CPM/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/Mandelbrot CPM/diskdefs
+++ b/Mandelbrot CPM/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/RetroNET Telnet CPM 2/diskdefs
+++ b/RetroNET Telnet CPM 2/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/RetroNET Telnet CPM/diskdefs
+++ b/RetroNET Telnet CPM/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/SET GET Cursor CPM/diskdefs
+++ b/SET GET Cursor CPM/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/Test Music/diskdefs
+++ b/Test Music/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/dump ram CPM/diskdefs
+++ b/dump ram CPM/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0

--- a/vt52 test/diskdefs
+++ b/vt52 test/diskdefs
@@ -2,7 +2,7 @@ diskdef naburn
     seclen 128
     tracks 16384
     sectrk 4
-    blocksize 2048
+    blocksize 4096
     maxdir 512
     skew 1
     boottrk 0


### PR DESCRIPTION
While trying to compile examples from this repo and run on my own system, I found that the blocksize in the `diskdefs` files was out of date.

After updating to 4096 I am able to run programs compiled for CPM using the compile  --> create disk image --> mount --> execute workflow.
